### PR TITLE
Deprecate Icon(String,String) constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>vaadin-icons-flow-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vaadin Icons Flow Parent</name>
 

--- a/vaadin-icons-flow-demo/pom.xml
+++ b/vaadin-icons-flow-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-icons-flow-demo</artifactId>

--- a/vaadin-icons-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-icons-flow-integration-tests/pom-bower-mode.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <groupId>com.vaadin</groupId>

--- a/vaadin-icons-flow-integration-tests/pom.xml
+++ b/vaadin-icons-flow-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-icons-flow-integration-tests</artifactId>

--- a/vaadin-icons-flow-testbench/pom.xml
+++ b/vaadin-icons-flow-testbench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-icons-testbench</artifactId>

--- a/vaadin-icons-flow/pom.xml
+++ b/vaadin-icons-flow/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-icons-flow-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-icons-flow</artifactId>

--- a/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -58,6 +58,17 @@ public class Icon extends Component implements HasStyle, ClickNotifier<Icon> {
         this(ICON_COLLECTION_NAME, icon.name().toLowerCase().replace('_', '-'));
     }
 
+	/**
+     * Creates an Icon component that displays the given icon from
+     * vaadin-icons collection.
+     *
+     * @param icon
+     *            the icon name
+     */
+    public Icon(String icon) {
+        this(ICON_COLLECTION_NAME, icon);
+    }
+	
     /**
      * Creates an Icon component that displays the given {@code icon} from the
      * given {@code collection}.
@@ -66,7 +77,10 @@ public class Icon extends Component implements HasStyle, ClickNotifier<Icon> {
      *            the icon collection
      * @param icon
      *            the icon name
+     * @deprecated Use either {@link #Icon(String)} or 
+     * {@link IronIcon#IronIcon(String,String) IronIcon(String,String)}
      */
+    @Deprecated
     public Icon(String collection, String icon) {
         // iron-icon's icon-attribute uses the format "collection:name",
         // e.g. icon="vaadin:arrow-down"


### PR DESCRIPTION
As discussed in https://github.com/vaadin/vaadin-icons-flow/issues/56, the `Icon(String,String)` constructor serves no purpose since both `Icon` is the same as `IronIcon` but the former also loads the `vaadin-icon` iconset, which is not needed unless the collection is `"vaadin"`.

Therefore:
 - Deprecate `Icon(String,String)` constructor 
 - Add an `Icon(String)` constructor, where the collection is always `"vaadin"`
 - Document that, when the collection is not `"vaadin"`, `IronIcon` should be used instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-icons-flow/57)
<!-- Reviewable:end -->
