### PR TITLE
Fixed turkish character problem with toLowerCase

### DIFF
--- a/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
+++ b/vaadin-icons-flow/src/main/java/com/vaadin/flow/component/icon/Icon.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.icon;
 
+import java.util.Locale;
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasStyle;
@@ -55,7 +56,7 @@ public class Icon extends Component implements HasStyle, ClickNotifier<Icon> {
      *            the icon to display
      */
     public Icon(VaadinIcon icon) {
-        this(ICON_COLLECTION_NAME, icon.name().toLowerCase().replace('_', '-'));
+        this(ICON_COLLECTION_NAME, icon.name().toLowerCase(Locale.ENGLISH).replace('_', '-'));
     }
 
     /**


### PR DESCRIPTION
Turkish alphabet contains uppercase I and its lowercase ı alongside another letter uppercase İ and its lowercase i .
When locale is set to turkish  toLowerCase() method changes  "ELLIPSIS-DOTS-V" to "ellıpsıs-dots-v" where as it should be "ellipsis-dots-v" for the icon to be displayed. To fix the problem Locale.ENGLISH should be passed to the toLowerCase method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-icons-flow/59)
<!-- Reviewable:end -->
